### PR TITLE
feat: remove basic tool and enable all Kong tools

### DIFF
--- a/src/kong_mcp_server/tools_config.json
+++ b/src/kong_mcp_server/tools_config.json
@@ -1,67 +1,60 @@
 {
   "tools": {
-    "hello_world": {
-      "name": "hello_world",
-      "description": "Simple Hello World tool for testing MCP server functionality",
-      "module": "kong_mcp_server.tools.basic",
-      "function": "hello_world",
-      "enabled": true
-    },
     "kong_get_services": {
       "name": "kong_get_services",
       "description": "Retrieve Kong services configuration",
       "module": "kong_mcp_server.tools.kong_services",
       "function": "get_services",
-      "enabled": false
+      "enabled": true
     },
     "kong_create_service": {
       "name": "kong_create_service",
       "description": "Create a new Kong service",
       "module": "kong_mcp_server.tools.kong_services",
       "function": "create_service",
-      "enabled": false
+      "enabled": true
     },
     "kong_update_service": {
       "name": "kong_update_service",
       "description": "Update an existing Kong service",
       "module": "kong_mcp_server.tools.kong_services",
       "function": "update_service",
-      "enabled": false
+      "enabled": true
     },
     "kong_delete_service": {
       "name": "kong_delete_service",
       "description": "Delete a Kong service",
       "module": "kong_mcp_server.tools.kong_services",
       "function": "delete_service",
-      "enabled": false
+      "enabled": true
     },
     "kong_get_routes": {
       "name": "kong_get_routes",
       "description": "Retrieve Kong routes configuration",
       "module": "kong_mcp_server.tools.kong_routes",
       "function": "get_routes",
-      "enabled": false
+      "enabled": true
     },
     "kong_create_route": {
       "name": "kong_create_route",
       "description": "Create a new Kong route",
       "module": "kong_mcp_server.tools.kong_routes",
       "function": "create_route",
-      "enabled": false
+      "enabled": true
     },
     "kong_update_route": {
       "name": "kong_update_route",
       "description": "Update an existing Kong route",
       "module": "kong_mcp_server.tools.kong_routes",
       "function": "update_route",
-      "enabled": false
+      "enabled": true
     },
     "kong_delete_route": {
       "name": "kong_delete_route",
       "description": "Delete a Kong route",
       "module": "kong_mcp_server.tools.kong_routes",
       "function": "delete_route",
-      "enabled": false
+      "enabled": true
     }
   }
 }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,9 +19,21 @@ async def test_server_tool_registration_integration() -> None:
         # Run setup_tools
         setup_tools()
 
-        # Check that hello_world tool is registered
+        # Check that Kong tools are registered
         if hasattr(mcp, "_tools"):
-            assert "hello_world" in mcp._tools
+            kong_tools = [
+                "kong_get_services",
+                "kong_create_service",
+                "kong_update_service",
+                "kong_delete_service",
+                "kong_get_routes",
+                "kong_create_route",
+                "kong_update_route",
+                "kong_delete_route",
+            ]
+            # At least some Kong tools should be registered
+            registered_kong_tools = [tool for tool in kong_tools if tool in mcp._tools]
+            assert len(registered_kong_tools) > 0
         else:
             # Alternative check if _tools attribute doesn't exist
             assert hasattr(mcp, "tool")
@@ -101,13 +113,7 @@ def test_tools_config_structure() -> None:
     assert "tools" in config
     assert isinstance(config["tools"], dict)
 
-    # Verify hello_world tool configuration
-    hello_world_config = config["tools"]["hello_world"]
-    assert hello_world_config["enabled"] is True
-    assert hello_world_config["module"] == "kong_mcp_server.tools.basic"
-    assert hello_world_config["function"] == "hello_world"
-
-    # Verify Kong tools are present but disabled
+    # Verify Kong tools are present and enabled
     kong_tools = [
         "kong_get_services",
         "kong_create_service",
@@ -121,7 +127,7 @@ def test_tools_config_structure() -> None:
 
     for tool_name in kong_tools:
         assert tool_name in config["tools"]
-        assert config["tools"][tool_name]["enabled"] is False
+        assert config["tools"][tool_name]["enabled"] is True
 
 
 def test_mcp_server_configuration() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -29,13 +29,24 @@ def test_load_tools_config() -> None:
 
     assert "tools" in config
     assert isinstance(config["tools"], dict)
-    assert "hello_world" in config["tools"]
 
-    hello_world_config = config["tools"]["hello_world"]
-    assert hello_world_config["name"] == "hello_world"
-    assert hello_world_config["module"] == "kong_mcp_server.tools.basic"
-    assert hello_world_config["function"] == "hello_world"
-    assert hello_world_config["enabled"] is True
+    # Verify Kong tools are present and enabled
+    kong_tools = [
+        "kong_get_services",
+        "kong_create_service",
+        "kong_update_service",
+        "kong_delete_service",
+        "kong_get_routes",
+        "kong_create_route",
+        "kong_update_route",
+        "kong_delete_route",
+    ]
+
+    for tool_name in kong_tools:
+        assert tool_name in config["tools"]
+        tool_config = config["tools"][tool_name]
+        assert tool_config["name"] == tool_name
+        assert tool_config["enabled"] is True
 
 
 @patch("builtins.open")


### PR DESCRIPTION
## Summary
- Remove hello_world tool from tools configuration
- Enable all Kong services and routes management tools  
- Update tests to reflect new tool configuration
- All tests passing with 96% code coverage

## Changes Made
- **Tools Configuration**: Updated `tools_config.json` to remove basic tool and enable all Kong tools
- **Test Updates**: Modified integration and server tests to work with new tool configuration
- **Coverage**: Maintained high test coverage (96%) with all tests passing

## Tools Now Enabled
### Kong Services Management
- `kong_get_services`: Retrieve Kong services configuration
- `kong_create_service`: Create a new Kong service
- `kong_update_service`: Update an existing Kong service
- `kong_delete_service`: Delete a Kong service

### Kong Routes Management  
- `kong_get_routes`: Retrieve Kong routes configuration
- `kong_create_route`: Create a new Kong route
- `kong_update_route`: Update an existing Kong route
- `kong_delete_route`: Delete a Kong route

## Test Plan
- [x] All unit tests pass (86 passed, 2 skipped)
- [x] Code coverage maintained at 96%
- [x] Tools configuration loads correctly
- [x] MCP server starts and registers all enabled tools
- [x] Integration tests verify tool registration and execution