### PR TITLE
Add Docker Host Configuration via EnvironmentVariable

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,15 @@ isort src/ tests/
 
 The Kong Rate Limiter MCP Server is available on Docker Hub as `shibbirmcc/kong-ratelimiter-mcp-server`.
 
+#### Host Configuration
+
+By default, the server binds to `127.0.0.1`, which works for local development but may not be accessible when running in Docker. For Docker deployments, especially on Windows, you might need to bind to `0.0.0.0` to allow external access:
+
+```bash
+# Run with custom host binding
+docker run -p 8080:8080 -e FASTMCP_HOST=0.0.0.0 shibbirmcc/kong-ratelimiter-mcp-server
+```
+
 #### Quick Start with Docker Hub
 
 ```bash

--- a/src/kong_mcp_server/server.py
+++ b/src/kong_mcp_server/server.py
@@ -240,11 +240,12 @@ def main() -> None:
     # Set up tools before starting the server
     setup_tools()
 
-    # Get port from environment variable with fallback to 8080
+    # Get host and port from environment variables with fallbacks
+    host = os.environ.get("FASTMCP_HOST", "127.0.0.1")
     port = int(os.environ.get("FASTMCP_PORT", "8080"))
 
     # Run the server with SSE transport on /sse/ endpoint
-    mcp.run("sse", path="/sse/", port=port)
+    mcp.run("sse", path="/sse/", host=host, port=port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

- Added a new "Host Configuration" section in the Docker Deployment documentation
- Documented the default host binding (`127.0.0.1`)
- Added example command showing how to set host to `0.0.0.0` using environment variables
- Placed the documentation strategically before the Quick Start section for better visibility

## Why This Change is Needed
Users running the server in Docker, particularly on Windows, may encounter connectivity issues due to the default host binding of `127.0.0.1`. This documentation makes it clear how to configure the host binding to `0.0.0.0` using environment variables, ensuring the server is accessible from outside the container.